### PR TITLE
[ISSUE #7] Fix minor issues

### DIFF
--- a/paf/paf_impl.py
+++ b/paf/paf_impl.py
@@ -269,6 +269,8 @@ class SSHConnection:
 
         if True == substitute_params:
             unescaped_cmd = re.sub(r'\$\$', '$', cmd)
+            unescaped_cmd = re.sub(r'\{\{', '{', cmd)
+            unescaped_cmd = re.sub(r'\}\}', '}', cmd)
 
         logger.info(f"{unescaped_cmd}")
 
@@ -549,6 +551,8 @@ class Subprocess:
 
         if True == substitute_params:
             unescaped_cmd = re.sub(r'\$\$', '$', cmd)
+            unescaped_cmd = re.sub(r'\{\{', '{', cmd)
+            unescaped_cmd = re.sub(r'\}\}', '}', cmd)
 
         logger.info(f"{unescaped_cmd}")
 
@@ -685,6 +689,10 @@ class Task:
 
     def execute(self):
         pass
+
+    def substitute_parameters(self, cmd):
+        template = Template(cmd)
+        return template.substitute(self.__dict__)
 
     def start(self):
 


### PR DESCRIPTION
- Add "substitute_parameters" method to the Task class, in order to allow the user to substitute parameters without running the command
- Fix issue with wrongly printed "{{" and "}}" strings after the command substitution